### PR TITLE
 Change `static const char*` to `static constexpr const char*`

### DIFF
--- a/instagram/inc/InstagramConstants.h
+++ b/instagram/inc/InstagramConstants.h
@@ -2,19 +2,19 @@
 #define INSTAGRAM_CONSTANTS
 
 namespace Instagram{
-    static const char* INSTAGRAM_HOST = "api.instagram.com";
-    static const char* AUTH_CODE_GRANT_TYPE = "authorization_code";
-    static const char* AUTH_TOKEN_ARG = "access_token";
-    static const char* GET_AUTH_CODE = "/oauth/access_token";
-    static const char* SELF = "self";
-    static const char* QUERY_ARG = "q";   
-    static const char* LAT_ARG = "lat";
-    static const char* LNG_ARG = "lng";
-    static const char* DST_ARG = "distance";
-    static const char* COUNT_ARG = "count";
-    static const char* MIN_ID_ARG = "min_id";
-    static const char* MAX_ID_ARG = "max_id";
-    static const char* MAX_LIKE_ID = "max_like_id";
+    static constexpr const char* INSTAGRAM_HOST = "api.instagram.com";
+    static constexpr const char* AUTH_CODE_GRANT_TYPE = "authorization_code";
+    static constexpr const char* AUTH_TOKEN_ARG = "access_token";
+    static constexpr const char* GET_AUTH_CODE = "/oauth/access_token";
+    static constexpr const char* SELF = "self";
+    static constexpr const char* QUERY_ARG = "q";   
+    static constexpr const char* LAT_ARG = "lat";
+    static constexpr const char* LNG_ARG = "lng";
+    static constexpr const char* DST_ARG = "distance";
+    static constexpr const char* COUNT_ARG = "count";
+    static constexpr const char* MIN_ID_ARG = "min_id";
+    static constexpr const char* MAX_ID_ARG = "max_id";
+    static constexpr const char* MAX_LIKE_ID = "max_like_id";
 }
 
 #endif

--- a/instagram/inc/InstagramEndpoints.h
+++ b/instagram/inc/InstagramEndpoints.h
@@ -7,49 +7,49 @@
 
 namespace Instagram{
     namespace Users{
-        static const char* users = "/v1/users/";
-        static const char* recent_media = "/media/recent";
-        static const char* search = "search";
-        static const char* self_liked = "self/media/liked";
+        static constexpr const char* users = "/v1/users/";
+        static constexpr const char* recent_media = "/media/recent";
+        static constexpr const char* search = "search";
+        static constexpr const char* self_liked = "self/media/liked";
     }
 
     namespace Relationships{
-        static const char* users = "/v1/users/";
-        static const char* follows  = "self/follows";
-        static const char* followed_by = "self/followed-by";
-        static const char* requested_by = "self/requested-by";
-        static const char* relationship = "/relationship/";
+        static constexpr const char* users = "/v1/users/";
+        static constexpr const char* follows  = "self/follows";
+        static constexpr const char* followed_by = "self/followed-by";
+        static constexpr const char* requested_by = "self/requested-by";
+        static constexpr const char* relationship = "/relationship/";
     }
 
     namespace Media{
-        static const char* get_media = "/v1/media/";
-        static const char* get_media_shortcode = "/v1/media/shortcode/";
-        static const char* media_search = "/v1/media/search/";
+        static constexpr const char* get_media = "/v1/media/";
+        static constexpr const char* get_media_shortcode = "/v1/media/shortcode/";
+        static constexpr const char* media_search = "/v1/media/search/";
 
     }
 
     namespace Comments{
-        static const char* TEXT_ARG = "text";
+        static constexpr const char* TEXT_ARG = "text";
         
-        static const char* media = "/v1/media/";
-        static const char* comments = "/comments/";
+        static constexpr const char* media = "/v1/media/";
+        static constexpr const char* comments = "/comments/";
     }
 
     namespace Likes{
-        static const char* media = "/v1/media/";
-        static const char* likes = "/likes";
+        static constexpr const char* media = "/v1/media/";
+        static constexpr const char* likes = "/likes";
     }
 
     namespace Tags{
-        static const char* tags = "/v1/tags/";
-        static const char* tags_search = "search/";
-        static const char* recent_media = "/media/recent/";
+        static constexpr const char* tags = "/v1/tags/";
+        static constexpr const char* tags_search = "search/";
+        static constexpr const char* recent_media = "/media/recent/";
     }
 
     namespace Locations{
-        static const char* locations = "/v1/locations/";
-        static const char* recent_media = "/media/recent/";
-        static const char* search = "search/";
+        static constexpr const char* locations = "/v1/locations/";
+        static constexpr const char* recent_media = "/media/recent/";
+        static constexpr const char* search = "search/";
     }
 }
 


### PR DESCRIPTION
Cool project! Here's a small trivial improvement - changing occurrences of `static const char*` to `static constexpr const char*` for your string constants and endpoints. I doubt it will have any beneficial effect with optimizations enabled, but `constexpr` is appropriate here as all these strings are known at compile time and are not subject to change.
